### PR TITLE
[FEAT] 상품 클릭 수 관련 API 통신 추가

### DIFF
--- a/src/views/broadcast/live-viewing.vue
+++ b/src/views/broadcast/live-viewing.vue
@@ -235,6 +235,9 @@ const sendWatchTime = async () => {
     console.error('Error adding watch time:', error);
   }
 };
+const incrementProductClicks = async (broadcastSeq, productSeq) => {
+  await axios.post(`http://localhost:8090/product-clicks/broadcast/${broadcastSeq}/product/${productSeq}/increment-click`)
+}
 
 const cleanSessionProperties = () => {
   session.value = undefined;
@@ -287,6 +290,7 @@ const updateModal = (value) => {
   isOpen.value = value;
 };
 const showProductDetails = (product) => {
+  incrementProductClicks(mySessionId.value, 3) // 프로덕트 seq 동적으로 바꿔야함
   selectedProduct.value = product;
 };
 const closePurchaseModal = () => {

--- a/src/views/broadcast/liveboard.vue
+++ b/src/views/broadcast/liveboard.vue
@@ -125,6 +125,7 @@ export default {
         console.log("세션은 이미 활성화 상태입니다.");
         return;
       }
+      this.createProductClicks(this.$route.params.broadcastId);
       this.OV = new OpenVidu();
       this.session = this.OV.initSession();
       this.session.on("streamCreated", ({stream}) => {
@@ -255,6 +256,14 @@ export default {
       });
       this.maxViewers = maxViewers;
       this.averageViewers = averageViewers;
+    },
+    async createProductClicks(broadcastSeq) {
+      try {
+        const response = await axios.post(`http://localhost:8090/product-clicks/broadcast/${broadcastSeq}`);
+        console.log('Product clicks created:', response.data);
+      } catch (error) {
+        console.error('Error creating product clicks:', error.response ? error.response.data : error.message);
+      }
     },
     loadLiveBroadcastInfo() {
       const broadcastId = this.$route.params.broadcastId;

--- a/src/views/broadcast/liveboard.vue
+++ b/src/views/broadcast/liveboard.vue
@@ -177,6 +177,7 @@ export default {
         elapsedTime,
       });
 
+      await this.updateProductClicks(this.mySessionId);
       // 평균 시청자수와 최대 시청자수, 방송 진행시간을 db에 반영하는 axios 요청
       await this.updateBroadcastStatistics({maxViewerCount, avgViewerCount, broadcastDuration: elapsedTime});
 
@@ -247,6 +248,14 @@ export default {
         console.log('Watch time calculated and deleted:', response.data);
       } catch (error) {
         console.error('Error calculating and deleting watch time:', error.response ? error.response.data : error.message);
+      }
+    },
+    async updateProductClicks(broadcastSeq){
+      try{
+        const response = await axios.post(`http://localhost:8090/product-clicks/broadcast/${broadcastSeq}/update-average-clicks`)
+        console.log(`성공적 클릭수 업데이트`);
+      } catch (error){
+        console.error('클릭수 업데이트 실패', error.response ? error.response.data : error.message);
       }
     },
     updateStatistics({maxViewers, averageViewers}) {


### PR DESCRIPTION
## 📕 제목
- #관련 이슈 번호

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 방송 시작 시 방송 상품 클릭 수 생성
- [x] 방송 상품 클릭 시 클릭수 증가 기능 추가
- [x] 방송 종료 시 평균 클릭 수 업데이트

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 상품 seq는 임시로 하드코딩 해놨습니다.
- 특이사항2
